### PR TITLE
Optimized metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
         <mockito.version>3.11.2</mockito.version>
         <prometheus.version>0.11.0</prometheus.version>
         <log4j.version>2.14.1</log4j.version>
+        <undertow.version>2.1.0.Final</undertow.version>
     </properties>
 
     <repositories>
@@ -66,30 +67,24 @@
 
         <!-- Metrics -->
         <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient</artifactId>
-            <version>${prometheus.version}</version>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <version>1.7.1</version>
         </dependency>
         <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_hotspot</artifactId>
-            <version>${prometheus.version}</version>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-core</artifactId>
+            <version>${undertow.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_httpserver</artifactId>
-            <version>${prometheus.version}</version>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-servlet</artifactId>
+            <version>${undertow.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.prometheus</groupId>
-            <artifactId>simpleclient_caffeine</artifactId>
-            <version>${prometheus.version}</version>
-            <exclusions>
-                <exclusion>
-                    <artifactId>caffeine</artifactId>
-                    <groupId>com.github.ben-manes.caffeine</groupId>
-                </exclusion>
-            </exclusions>
+            <groupId>io.undertow</groupId>
+            <artifactId>undertow-websockets-jsr</artifactId>
+            <version>${undertow.version}</version>
         </dependency>
 
         <!-- Repository -->

--- a/src/main/java/de/timmi6790/discord_framework/DiscordBot.java
+++ b/src/main/java/de/timmi6790/discord_framework/DiscordBot.java
@@ -7,9 +7,6 @@ import de.timmi6790.discord_framework.module.ModuleStatus;
 import de.timmi6790.discord_framework.module.provider.providers.InternalModuleProvider;
 import de.timmi6790.discord_framework.module.provider.providers.jar.JarModuleProvider;
 import de.timmi6790.discord_framework.utilities.commons.GsonUtilities;
-import io.prometheus.client.cache.caffeine.CacheMetricsCollector;
-import io.prometheus.client.exporter.HTTPServer;
-import io.prometheus.client.hotspot.DefaultExports;
 import io.sentry.Sentry;
 import lombok.Getter;
 import lombok.SneakyThrows;
@@ -34,8 +31,6 @@ import java.util.concurrent.TimeUnit;
 @Log4j2
 public class DiscordBot {
     public static final String BOT_VERSION = "3.1.6";
-    // We need to register it here, because we can only have one global instance of the cache metrics
-    public static final CacheMetricsCollector CACHE_METRICS = new CacheMetricsCollector().register();
 
     private static final DiscordBot INSTANCE = new DiscordBot();
 
@@ -57,10 +52,6 @@ public class DiscordBot {
     }
 
     protected boolean setup() throws IOException {
-        // Metrics
-        DefaultExports.initialize();
-        new HTTPServer(8001);
-
         // Config
         final Path configFolderPath = Paths.get("./configs/");
         Files.createDirectories(configFolderPath);

--- a/src/main/java/de/timmi6790/discord_framework/module/modules/metric/MetricModule.java
+++ b/src/main/java/de/timmi6790/discord_framework/module/modules/metric/MetricModule.java
@@ -2,16 +2,17 @@ package de.timmi6790.discord_framework.module.modules.metric;
 
 import de.timmi6790.discord_framework.module.AbstractModule;
 import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.prometheus.client.CollectorRegistry;
-import io.prometheus.client.Gauge;
 import io.undertow.Undertow;
 import io.undertow.util.Headers;
 import lombok.EqualsAndHashCode;
@@ -19,28 +20,13 @@ import lombok.Getter;
 import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.sharding.ShardManager;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.TimeUnit;
-
 @EqualsAndHashCode(callSuper = true)
 @Log4j2
 public class MetricModule extends AbstractModule {
-    private static final Gauge DISCORD_GUILDS = Gauge.build()
-            .name("discord_guilds")
-            .help("Discord guilds.")
-            .register();
-
-    private static final Gauge DISCORD_SHARDS_RUNNING = Gauge.build()
-            .name("discord_shards_running")
-            .help("Discord running shards.")
-            .register();
-
     @Getter
     private PrometheusMeterRegistry meterRegistry;
 
     private Undertow metricsServer;
-    private ScheduledFuture<?> executorService;
 
     public MetricModule() {
         super("Metric");
@@ -56,15 +42,40 @@ public class MetricModule extends AbstractModule {
         this.metricsServer.start();
     }
 
-    private void registerJvmMetrics(final MeterRegistry registry) {
+    private void registerMetrics(final MeterRegistry registry) {
+        // Jvm metrics
         new ClassLoaderMetrics().bindTo(registry);
         new JvmMemoryMetrics().bindTo(registry);
         new ProcessorMetrics().bindTo(registry);
         new JvmThreadMetrics().bindTo(registry);
+        new UptimeMetrics().bindTo(registry);
 
         try (final JvmGcMetrics gcMetrics = new JvmGcMetrics()) {
             gcMetrics.bindTo(registry);
         }
+
+        // Discord metrics
+        final ShardManager discord = this.getDiscord();
+        Gauge
+                .builder("discord.guilds", discord, d -> d.getGuilds().size())
+                .description("discord guild count")
+                .register(registry);
+
+        Gauge
+                .builder("discord.shards", discord, ShardManager::getShardsRunning)
+                .tags("state", "running")
+                .description("discord shards")
+                .register(registry);
+        Gauge
+                .builder("discord.shards", discord, ShardManager::getShardsQueued)
+                .tags("state", "queued")
+                .description("discord shards")
+                .register(registry);
+
+        Gauge
+                .builder("discord.gateway.ping", discord, ShardManager::getAverageGatewayPing)
+                .description("discord average gateway ping")
+                .register(registry);
     }
 
     @Override
@@ -76,28 +87,13 @@ public class MetricModule extends AbstractModule {
         );
 
         this.startMetricsServer();
-        this.registerJvmMetrics(this.meterRegistry);
-
-        return true;
-    }
-
-    @Override
-    public boolean onEnable() {
-        this.executorService = Executors.newSingleThreadScheduledExecutor().scheduleAtFixedRate(
-                () -> {
-                    final ShardManager discord = this.getDiscord();
-                    DISCORD_GUILDS.set(discord.getGuilds().size());
-                    DISCORD_SHARDS_RUNNING.set(discord.getShardsRunning());
-                },
-                0, 10, TimeUnit.SECONDS
-        );
+        this.registerMetrics(this.meterRegistry);
 
         return true;
     }
 
     @Override
     public boolean onDisable() {
-        this.executorService.cancel(true);
         this.metricsServer.stop();
         return true;
     }

--- a/src/main/java/de/timmi6790/discord_framework/module/modules/metric/MetricModule.java
+++ b/src/main/java/de/timmi6790/discord_framework/module/modules/metric/MetricModule.java
@@ -1,8 +1,22 @@
 package de.timmi6790.discord_framework.module.modules.metric;
 
 import de.timmi6790.discord_framework.module.AbstractModule;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
+import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
+import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
 import io.prometheus.client.Gauge;
+import io.undertow.Undertow;
+import io.undertow.util.Headers;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 import net.dv8tion.jda.api.sharding.ShardManager;
 
 import java.util.concurrent.Executors;
@@ -10,6 +24,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 @EqualsAndHashCode(callSuper = true)
+@Log4j2
 public class MetricModule extends AbstractModule {
     private static final Gauge DISCORD_GUILDS = Gauge.build()
             .name("discord_guilds")
@@ -21,10 +36,49 @@ public class MetricModule extends AbstractModule {
             .help("Discord running shards.")
             .register();
 
+    @Getter
+    private PrometheusMeterRegistry meterRegistry;
+
+    private Undertow metricsServer;
     private ScheduledFuture<?> executorService;
 
     public MetricModule() {
         super("Metric");
+    }
+
+    private void startMetricsServer() {
+        this.metricsServer = Undertow.builder()
+                .addHttpListener(8001, "127.0.0.1")
+                .setHandler(exchange -> {
+                    exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "text/plain");
+                    exchange.getResponseSender().send(this.meterRegistry.scrape());
+                }).build();
+        this.metricsServer.start();
+    }
+
+    private void registerJvmMetrics(final MeterRegistry registry) {
+        new ClassLoaderMetrics().bindTo(registry);
+        new JvmMemoryMetrics().bindTo(registry);
+        new ProcessorMetrics().bindTo(registry);
+        new JvmThreadMetrics().bindTo(registry);
+
+        try (final JvmGcMetrics gcMetrics = new JvmGcMetrics()) {
+            gcMetrics.bindTo(registry);
+        }
+    }
+
+    @Override
+    public boolean onInitialize() {
+        this.meterRegistry = new PrometheusMeterRegistry(
+                PrometheusConfig.DEFAULT,
+                CollectorRegistry.defaultRegistry,
+                Clock.SYSTEM
+        );
+
+        this.startMetricsServer();
+        this.registerJvmMetrics(this.meterRegistry);
+
+        return true;
     }
 
     @Override
@@ -37,12 +91,14 @@ public class MetricModule extends AbstractModule {
                 },
                 0, 10, TimeUnit.SECONDS
         );
+
         return true;
     }
 
     @Override
     public boolean onDisable() {
         this.executorService.cancel(true);
+        this.metricsServer.stop();
         return true;
     }
 }

--- a/src/main/java/de/timmi6790/discord_framework/module/modules/reactions/button/ButtonReactionModule.java
+++ b/src/main/java/de/timmi6790/discord_framework/module/modules/reactions/button/ButtonReactionModule.java
@@ -2,11 +2,12 @@ package de.timmi6790.discord_framework.module.modules.reactions.button;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import de.timmi6790.discord_framework.DiscordBot;
 import de.timmi6790.discord_framework.module.AbstractModule;
 import de.timmi6790.discord_framework.module.modules.event.EventModule;
+import de.timmi6790.discord_framework.module.modules.metric.MetricModule;
 import de.timmi6790.discord_framework.module.modules.reactions.button.listeners.ButtonReactionListener;
 import de.timmi6790.discord_framework.module.modules.reactions.common.cache.CacheExpireAfter;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 import lombok.EqualsAndHashCode;
 import lombok.NonNull;
 import net.dv8tion.jda.api.entities.Message;
@@ -27,8 +28,10 @@ public class ButtonReactionModule extends AbstractModule {
         this.addDependenciesAndLoadAfter(
                 EventModule.class
         );
-
-        DiscordBot.CACHE_METRICS.addCache("reaction_button_message_cache", this.messageCache);
+        
+        this.addLoadAfterDependencies(
+                MetricModule.class
+        );
     }
 
     @Override
@@ -37,6 +40,16 @@ public class ButtonReactionModule extends AbstractModule {
                 .addEventListener(
                         new ButtonReactionListener(this)
                 );
+
+        // Register metrics
+        this.getModule(MetricModule.class).ifPresent(metric ->
+                CaffeineCacheMetrics.monitor(
+                        metric.getMeterRegistry(),
+                        this.messageCache,
+                        "reaction_button_message"
+                )
+        );
+
         return true;
     }
 

--- a/src/test/java/de/timmi6790/discord_framework/module/modules/guild/GuildDbModuleTest.java
+++ b/src/test/java/de/timmi6790/discord_framework/module/modules/guild/GuildDbModuleTest.java
@@ -2,8 +2,8 @@ package de.timmi6790.discord_framework.module.modules.guild;
 
 import de.timmi6790.discord_framework.AbstractIntegrationTest;
 import de.timmi6790.discord_framework.DiscordBot;
+import de.timmi6790.discord_framework.module.ModuleManager;
 import de.timmi6790.discord_framework.module.modules.database.DatabaseModule;
-import de.timmi6790.discord_framework.module.modules.setting.SettingModule;
 import net.dv8tion.jda.api.sharding.ShardManager;
 import org.assertj.core.api.AssertionsForClassTypes;
 import org.junit.jupiter.api.BeforeAll;
@@ -25,11 +25,13 @@ class GuildDbModuleTest {
 
     @BeforeAll
     static void setUp() {
-        doReturn(AbstractIntegrationTest.databaseModule).when(guildDbModule).getModuleOrThrow(DatabaseModule.class);
-        doReturn(Optional.empty()).when(guildDbModule).getModule(SettingModule.class);
+        final ModuleManager moduleManager = mock(ModuleManager.class);
+        when(moduleManager.getModuleOrThrow(DatabaseModule.class)).thenReturn(AbstractIntegrationTest.databaseModule);
+        when(moduleManager.getModuleOrThrow(GuildDbModule.class)).thenReturn(guildDbModule);
 
         try (final MockedStatic<DiscordBot> botMock = mockStatic(DiscordBot.class)) {
             final DiscordBot bot = mock(DiscordBot.class);
+            when(bot.getModuleManager()).thenReturn(moduleManager);
 
             final ShardManager discord = mock(ShardManager.class);
             when(bot.getDiscord()).thenReturn(discord);


### PR DESCRIPTION
I need to re-add the command metrics during the command module cleanup

- Replace prometheus dependencies with micrometer prometheus 
- Add undertow dependency for the metric broadcast server
- Move metrics register from DiscordBot into MetricModule
- Add application uptime metrics
- Add discord gateway average ping metric
- Add discord queued shards metric
- Add hikaricp metrics